### PR TITLE
Improve match history and add admin balance modal

### DIFF
--- a/src/components/BalanceAdminModal.tsx
+++ b/src/components/BalanceAdminModal.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { motion } from 'framer-motion';
+import { X, DollarSign } from 'lucide-react';
+import api from '../api';
+import { toast } from 'react-hot-toast';
+
+interface Player {
+  id: string;
+  summoner: string;
+}
+
+interface Props {
+  sessionId: string;
+  players: Player[];
+  onClose: () => void;
+  onUpdated: () => void;
+}
+
+export default function BalanceAdminModal({ sessionId, players, onClose, onUpdated }: Props) {
+  const [playerId, setPlayerId] = useState(players[0]?.id ?? '');
+  const [amount, setAmount] = useState(0);
+
+  const adjust = async (delta: number) => {
+    if (!playerId || amount <= 0) return;
+    try {
+      await api.post(`/admin/sessions/${sessionId}/currency`, { playerId, amount: delta });
+      toast.success('Balance updated');
+      onUpdated();
+      onClose();
+    } catch (err: any) {
+      toast.error(err.response?.data?.error || 'Failed to update balance');
+    }
+  };
+
+  return (
+    <motion.div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+      <motion.div initial={{ scale: 0.8, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.8, opacity: 0 }} transition={{ type: 'spring', stiffness: 300, damping: 25 }} className="relative w-full max-w-sm bg-white/10 backdrop-blur-lg rounded-2xl shadow-xl p-6 glass-border">
+        <button onClick={onClose} className="absolute top-4 right-4 text-slate-300 hover:text-slate-100">
+          <X />
+        </button>
+        <h3 className="text-xl font-semibold text-slate-100 mb-4">Adjust Balance</h3>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-slate-200 mb-1">Player</label>
+            <select value={playerId} onChange={e => setPlayerId(e.target.value)} className="w-full bg-black/30 text-slate-100 p-2 rounded">
+              {players.map(p => (
+                <option key={p.id} value={p.id}>{p.summoner}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-slate-200 mb-1">Amount (Victor Bucks)</label>
+            <div className="flex items-center bg-black/30 rounded">
+              <DollarSign className="m-2 w-5 h-5 text-yellow-300" />
+              <input type="number" value={amount} onChange={e => setAmount(parseInt(e.target.value) || 0)} className="w-full bg-transparent p-2 text-slate-100 focus:outline-none" min={1} step={1} />
+            </div>
+          </div>
+          <div className="flex gap-3">
+            <button onClick={() => adjust(amount)} className="flex-1 py-2 bg-green-500/30 hover:bg-green-500/50 text-green-200 rounded-md">Add</button>
+            <button onClick={() => adjust(-amount)} className="flex-1 py-2 bg-red-500/30 hover:bg-red-500/50 text-red-200 rounded-md">Remove</button>
+          </div>
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/src/components/MatchHistory.tsx
+++ b/src/components/MatchHistory.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { motion } from 'framer-motion';
+import React, { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 
 interface MatchStat {
   id: string;
@@ -39,6 +39,7 @@ export default function MatchHistory({ matches, bets }: Props) {
     const timestampB = new Date(matches[b][0].timestamp).getTime();
     return timestampB - timestampA;
   });
+  const [openMatch, setOpenMatch] = useState<string | null>(null);
 
   return (
     <div className="w-full space-y-6">
@@ -64,10 +65,13 @@ export default function MatchHistory({ matches, bets }: Props) {
               key={matchId}
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
-              className="bg-glass-strong backdrop-blur-glass border border-neon-purple/20 rounded-lg p-4"
+              className="bg-glass-strong backdrop-blur-glass border border-neon-purple/20 rounded-lg"
             >
               {/* Match Header */}
-              <div className="flex justify-between items-center mb-4">
+              <button
+                onClick={() => setOpenMatch(m => (m === matchId ? null : matchId))}
+                className="w-full flex justify-between items-center p-4"
+              >
                 <div>
                   <h4 className="text-lg font-display text-neon-blue">Match {matchId.slice(-8)}</h4>
                   <p className="text-sm text-slate-400">{timestamp}</p>
@@ -75,62 +79,71 @@ export default function MatchHistory({ matches, bets }: Props) {
                 <div className={`text-lg font-mono font-bold ${totalPayout >= 0 ? 'text-neon-green' : 'text-red-400'}`}>
                   {totalPayout >= 0 ? '+' : ''}{totalPayout} VB
                 </div>
-              </div>
+              </button>
 
-              {/* Player Stats */}
-              <div className="grid grid-cols-2 gap-4 mb-4">
-                {matchStats.map(stat => (
-                  <div key={stat.id} className="bg-black/30 rounded-lg p-3">
-                    <div className="text-neon-silver font-display mb-1">{stat.player.summoner}</div>
-                    <div className="grid grid-cols-2 gap-2 text-sm">
-                      <div className="text-slate-300">K/D/A:</div>
-                      <div className="text-neon-green font-mono">{stat.kills}/{stat.deaths}/{stat.assists}</div>
-                      <div className="text-slate-300">Damage:</div>
-                      <div className="text-neon-purple font-mono">{stat.damage.toLocaleString()}</div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-
-              {/* Bets */}
-              {matchBets.length > 0 && (
-                <div>
-                  <h5 className="text-sm font-display text-slate-300 mb-2">Bets</h5>
-                  <div className="space-y-2">
-                    {matchBets.map(bet => (
-                      <div 
-                        key={bet.id}
-                        className={`flex justify-between items-center p-2 rounded ${
-                          bet.won 
-                            ? 'bg-neon-green/10 text-neon-green' 
-                            : 'bg-red-500/10 text-red-400'
-                        }`}
-                      >
-                        <div>
-                          <span className="font-display">{bet.bettor.summoner}</span>
-                          <span className="text-slate-400 mx-1">→</span>
-                          <span className="font-mono">{bet.amount}</span>
-                          <span className="text-slate-400 mx-1">on</span>
-                          <span className="font-display">{bet.player.summoner}</span>
-                          <span className="text-slate-400 mx-1">for</span>
-                          <span>{bet.category}</span>
+              <AnimatePresence initial={false}>
+                {openMatch === matchId && (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: 'auto', opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    className="px-4 pb-4 space-y-4 overflow-hidden"
+                  >
+                    <div className="grid grid-cols-2 gap-4">
+                      {matchStats.map(stat => (
+                        <div key={stat.id} className="bg-black/30 rounded-lg p-3">
+                          <div className="text-neon-silver font-display mb-1">{stat.player.summoner}</div>
+                          <div className="grid grid-cols-2 gap-2 text-sm">
+                            <div className="text-slate-300">K/D/A:</div>
+                            <div className="text-neon-green font-mono">{stat.kills}/{stat.deaths}/{stat.assists}</div>
+                            <div className="text-slate-300">Damage:</div>
+                            <div className="text-neon-purple font-mono">{stat.damage.toLocaleString()}</div>
+                          </div>
                         </div>
-                        <div className="font-mono">
-                          {bet.won 
-                            ? `+${(bet.amount * bet.odds).toFixed(0)}`
-                            : `-${bet.amount}`
-                          }
+                      ))}
+                    </div>
+
+                    {matchBets.length > 0 && (
+                      <div>
+                        <h5 className="text-sm font-display text-slate-300 mb-2">Bets</h5>
+                        <div className="space-y-2">
+                          {matchBets.map(bet => (
+                            <div
+                              key={bet.id}
+                              className={`flex justify-between items-center p-2 rounded ${
+                                bet.won
+                                  ? 'bg-neon-green/10 text-neon-green'
+                                  : 'bg-red-500/10 text-red-400'
+                              }`}
+                            >
+                              <div>
+                                <span className="font-display">{bet.bettor.summoner}</span>
+                                <span className="text-slate-400 mx-1">→</span>
+                                <span className="font-mono">{bet.amount}</span>
+                                <span className="text-slate-400 mx-1">on</span>
+                                <span className="font-display">{bet.player.summoner}</span>
+                                <span className="text-slate-400 mx-1">for</span>
+                                <span>{bet.category}</span>
+                              </div>
+                              <div className="font-mono">
+                                {bet.won
+                                  ? `+${(bet.amount * bet.odds).toFixed(0)}`
+                                  : `-${bet.amount}`
+                                }
+                              </div>
+                            </div>
+                          ))}
                         </div>
                       </div>
-                    ))}
-                  </div>
-                </div>
-              )}
+                    )}
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </motion.div>
           );
         })}
       </div>
     </div>
   );
-} 
+}
 


### PR DESCRIPTION
## Summary
- add BalanceAdminModal for adjusting player currency
- filter session history by session start time
- redesign match history with collapsible cards
- allow 'admin' key combo to open balance admin modal

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68409bad4f9883228ec1cdb9fafe3357