### PR TITLE
Handle balance update socket event

### DIFF
--- a/src/components/BalanceAdminModal.tsx
+++ b/src/components/BalanceAdminModal.tsx
@@ -23,7 +23,7 @@ export default function BalanceAdminModal({ sessionId, players, onClose, onUpdat
   const adjust = async (delta: number) => {
     if (!playerId || amount <= 0) return;
     try {
-      await api.post(`/admin/sessions/${sessionId}/currency`, { playerId, amount: delta });
+      await api.post(`/sessions/${sessionId}/currency`, { playerId, amount: delta });
       toast.success('Balance updated');
       onUpdated();
       onClose();

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -164,6 +164,9 @@ export default function Session() {
 
     socket.on('ODDS_READY', fetchOddsData);
     socket.on('BET_PLACED', refreshBets);
+    socket.on('PLAYER_BALANCE_UPDATED', ({ playerId, balance }) => {
+      setPlayers(ps => ps.map(p => p.id === playerId ? { ...p, balance } : p));
+    });
 
     return () => {
       socket.off('PLAYER_JOINED');
@@ -174,6 +177,7 @@ export default function Session() {
       socket.off('GAME_ENDED');
       socket.off('ODDS_READY');
       socket.off('BET_PLACED');
+      socket.off('PLAYER_BALANCE_UPDATED');
     };
   }, [id, navigate, paused, fetchOddsData]);
 
@@ -204,8 +208,12 @@ export default function Session() {
     return () => window.removeEventListener('keydown', handleKey);
   }, []);
 
-  /* ── fetch match history on mount ────────────────────────────────────── */
-  useEffect(() => { fetchMatchHistory(); }, [fetchMatchHistory]);
+  /* ── fetch match history only when session start is known ────────────── */
+  useEffect(() => {
+    if (sessionStartAt) {
+      fetchMatchHistory();
+    }
+  }, [fetchMatchHistory, sessionStartAt]);
 
   /* ── Loading screen ─────────────────────────────────────────────────── */
   if (loading) {


### PR DESCRIPTION
## Summary
- listen for PLAYER_BALANCE_UPDATED socket event
- update player balances live in Session page
- call new player balance endpoint
- refresh match history only after session start is known

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840a481fa708322acd383dfb9d1b146